### PR TITLE
Read the docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python:
+    python: "3.12"
 
 mkdocs:
   configuration: mkdocs.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,8 @@ version: 2
 # Set the build setup
 build:
   os: ubuntu-24.04
+  tools:
+    python:
 
 mkdocs:
   configuration: mkdocs.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,5 +14,3 @@ build:
 mkdocs:
   configuration: mkdocs.yml
   fail_on_warning: false
-
-python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,13 @@
+
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the build setup
+build:
+  os: ubuntu-24.04
+
+mkdocs:
+  configuration: mkdocs.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,3 +11,6 @@ build:
 
 mkdocs:
   configuration: mkdocs.yml
+  fail_on_warning: false
+
+python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,3 +14,7 @@ build:
 mkdocs:
   configuration: mkdocs.yml
   fail_on_warning: false
+
+python:
+  install:
+  - requirements: docs/requirements.txt

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@
 ## What it does
 
 The purpose of **WallGoCollision** is to compute integrals of form
-$$
-\mathcal{C}_a[\delta f] \propto \sum_{bcd} \int \frac{d^3\mathbf{p}_2 d^3\mathbf{p}_3 d^3\mathbf{p}_4}{E_2 E_3 E_4} \delta^4(p_1 + p_2 - p_3 - p_4) |M_{ab \rightarrow cd}(p_1, p_2; p_3, p_4)|^2 \mathcal{P}_{ab \rightarrow cd}[\delta f],
-$$
+
+$$\mathcal{C}_a[\delta f] \propto \sum_{bcd} \int \frac{d^3\mathbf{p}_2 d^3\mathbf{p}_3 d^3\mathbf{p}_4}{E_2 E_3 E_4} \delta^4(p_1 + p_2 - p_3 - p_4) |M_{ab \rightarrow cd}(p_1, p_2; p_3, p_4)|^2 \mathcal{P}_{ab \rightarrow cd}[\delta f],$$
+
 appearing in the collision operator of the relativistic Boltzmann equation for particle species $a$. **WallGo**, and **WallGoCollision** by extension, uses the spectral approach of Cline & Laurent ([paper](https://journals.aps.org/prd/abstract/10.1103/PhysRevD.106.023501)) to Boltzmann integration, meaning the integrals must be evaluated on a 4D grid of momenta and suitable basis polynomials. The integrations are performed using importance-sampled Monte Carlo. Integrals on different grid points are independent and trivially computable in parallel. We support OpenMP for parallel evaluation. Currently **WallGoCollision** is restricted to the linearized version of collision integrals. See [the physics page](./physics.md) for more details on the physics.
 
 The user must provide relevant particle content for their model, matrix elements $M_{ab \rightarrow cd}$ of their choice in a symbolic form, and numerical values for model parameters appearing in the matrix elements. To get started, see [the quickstart page](./quickstart.md), [code examples in C++](../examples) or [code examples using the Python interface on **WallGo** repo](https://github.com/Wall-Go/WallGo/tree/main/Models).

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@
 ## What it does
 
 The purpose of **WallGoCollision** is to compute integrals of form
-```math
+$$
 \mathcal{C}_a[\delta f] \propto \sum_{bcd} \int \frac{d^3\mathbf{p}_2 d^3\mathbf{p}_3 d^3\mathbf{p}_4}{E_2 E_3 E_4} \delta^4(p_1 + p_2 - p_3 - p_4) |M_{ab \rightarrow cd}(p_1, p_2; p_3, p_4)|^2 \mathcal{P}_{ab \rightarrow cd}[\delta f],
-```
+$$
 appearing in the collision operator of the relativistic Boltzmann equation for particle species $a$. **WallGo**, and **WallGoCollision** by extension, uses the spectral approach of Cline & Laurent ([paper](https://journals.aps.org/prd/abstract/10.1103/PhysRevD.106.023501)) to Boltzmann integration, meaning the integrals must be evaluated on a 4D grid of momenta and suitable basis polynomials. The integrations are performed using importance-sampled Monte Carlo. Integrals on different grid points are independent and trivially computable in parallel. We support OpenMP for parallel evaluation. Currently **WallGoCollision** is restricted to the linearized version of collision integrals. See [the physics page](./physics.md) for more details on the physics.
 
 The user must provide relevant particle content for their model, matrix elements $M_{ab \rightarrow cd}$ of their choice in a symbolic form, and numerical values for model parameters appearing in the matrix elements. To get started, see [the quickstart page](./quickstart.md), [code examples in C++](../examples) or [code examples using the Python interface on **WallGo** repo](https://github.com/Wall-Go/WallGo/tree/main/Models).

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,19 @@
+window.MathJax = {
+    tex: {
+        inlineMath: [["$", "$"]],
+        displayMath: [["$$", "$$"]],
+        processEscapes: true,
+        processEnvironments: true
+    },
+    options: {
+        ignoreHtmlClass: ".*|",
+        processHtmlClass: "arithmatex"
+    }
+};
+  
+document$.subscribe(() => { 
+    MathJax.startup.output.clearCache()
+    MathJax.typesetClear()
+    MathJax.texReset()
+    MathJax.typesetPromise()
+})

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,7 +1,5 @@
 window.MathJax = {
     tex: {
-        inlineMath: [["\(", "\)"]],
-        displayMath: [["$$", "$$"]],
         processEscapes: true,
         processEnvironments: true
     },

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,7 +1,7 @@
 window.MathJax = {
     tex: {
-        inlineMath: [["$", "$"]],
-        displayMath: [["$$", "$$"]],
+        inlineMath: [["\$", "\$"]],
+        displayMath: [["\$\$", "\$\$"]],
         processEscapes: true,
         processEnvironments: true
     },

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,7 +1,7 @@
 window.MathJax = {
     tex: {
-        inlineMath: [["\$", "\$"]],
-        displayMath: [["\$\$", "\$\$"]],
+        inlineMath: [["\(", "\)"]],
+        displayMath: [["$$", "$$"]],
         processEscapes: true,
         processEnvironments: true
     },

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -3,9 +3,9 @@
 Here, we give a brief overview on the physics background of the WallGo Collision package. For a more detailed discussion see [arXiv:2410.00000](https://arxiv.org/abs/2410.00000).
 
 The WallGo Collision package computes the collision matrix, $\mathcal C^{\text{lin}}_{ab}$, in the linearized collision term of a Boltzmann equation:
-```math
+$$
 	\left(p^\mu \partial_\mu + \frac{1}{2}\vec{\nabla }m_a^2\cdot \nabla_{\vec{p}}\right) f^a = -\mathcal C^{\text{lin}}_{ab}[\delta f^b].
-```
+$$
 Here, the indices $a,b$ refer to different particle species, $f^a$ is the particle distribution function and $\delta f^a$ is the deviation from the equilibrium distribution.
 The Boltzmann equation plays an important role for accurately determining the velocity of a bubble wall: It describes the evolution of the off-equilibrium particle distribution functions, $\delta f^b$, which can induce a friction force on the moving wall.
 

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -3,9 +3,9 @@
 Here, we give a brief overview on the physics background of the WallGo Collision package. For a more detailed discussion see [arXiv:2410.00000](https://arxiv.org/abs/2410.00000).
 
 The WallGo Collision package computes the collision matrix, $\mathcal C^{\text{lin}}_{ab}$, in the linearized collision term of a Boltzmann equation:
-$$
-	\left(p^\mu \partial_\mu + \frac{1}{2}\vec{\nabla }m_a^2\cdot \nabla_{\vec{p}}\right) f^a = -\mathcal C^{\text{lin}}_{ab}[\delta f^b].
-$$
+
+$$\left(p^\mu \partial_\mu + \frac{1}{2}\vec{\nabla }m_a^2\cdot \nabla_{\vec{p}}\right) f^a = -\mathcal C^{\text{lin}}_{ab}[\delta f^b].$$
+
 Here, the indices $a,b$ refer to different particle species, $f^a$ is the particle distribution function and $\delta f^a$ is the deviation from the equilibrium distribution.
 The Boltzmann equation plays an important role for accurately determining the velocity of a bubble wall: It describes the evolution of the off-equilibrium particle distribution functions, $\delta f^b$, which can induce a friction force on the moving wall.
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs
+pymdown-extensions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,8 +7,6 @@ plugins:
 markdown_extensions:
   - pymdownx.arithmatex:
     generic: true
-  - markdown_include.include:
-    base_path: .
 extra_javascript:
   - javascripts/mathjax.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,6 @@
+site_name: WallGoCollision
+theme:
+  name: readthedocs
+  highlightjs: true
+markdown_extensions:
+  - footnoes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ markdown_extensions:
   - pymdownx.arithmatex:
     generic: true
   - markdown_include.include:
-    base_path: ./docs
+    base_path: .
 extra_javascript:
   - javascripts/mathjax.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ theme:
 plugins:
   - search
 markdown_extensions:
+  - pymdownx.betterem
   - pymdownx.arithmatex:
       generic: true
 extra_javascript:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ plugins:
   - search
 markdown_extensions:
   - pymdownx.arithmatex:
-    generic: true
+      generic: true
 extra_javascript:
   - javascripts/mathjax.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,3 +6,5 @@ plugins:
   - search
 markdown_extensions:
   - footnotes
+  - markdown_include.include:
+      base_path: .

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ plugins:
 markdown_extensions:
   - footnotes
   - markdown_include.include:
-      base_path: .
+    base_path: ./docs
   - pymdownx.arithmatex:
     generic: true
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,3 +8,9 @@ markdown_extensions:
   - footnotes
   - markdown_include.include:
       base_path: .
+  - pymdownx.arithmatex:
+    generic: true
+
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,5 +2,7 @@ site_name: WallGoCollision
 theme:
   name: readthedocs
   highlightjs: true
+plugins:
+  - search
 markdown_extensions:
-  - footnoes
+  - footnotes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,12 +5,10 @@ theme:
 plugins:
   - search
 markdown_extensions:
-  - footnotes
-  - markdown_include.include:
-    base_path: ./docs
   - pymdownx.arithmatex:
     generic: true
-
+  - markdown_include.include:
+    base_path: ./docs
 extra_javascript:
   - javascripts/mathjax.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
A rudimentary attempt at getting the WallGoCollision docs onto ReadTheDocs. Output can be found here:
https://wallgocollision.readthedocs.io/
For comparison, here are the WallGo docs:
https://wallgo.readthedocs.io/