### PR TITLE
Build system improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,4 +67,3 @@ docs/_build
 
 # Weird mac things
 *.DS_Store
-*/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ bin/*
 examples/bin/
 python/package_standalone/WallGoCollision/*
 *_generated.h
+_version.py
 
 # Data files
 *.hdf5
@@ -62,6 +63,7 @@ wheels/
 docs/_build
 *.pyd
 *.pyi
+*.whl
 
 # Weird mac things
 *.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 3.18)
-project(Collision VERSION 0.2.0 LANGUAGES CXX)
 
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+
+include(${CMAKE_SOURCE_DIR}/cmake/GenerateProjectVersion.cmake)
+GenerateProjectVersion(WALLGOCOLLISION_VERSION)
+
+project(Collision VERSION ${WALLGOCOLLISION_VERSION} LANGUAGES CXX)
 
 option(USE_CXX20 "Prefer C++20 if available (may allow small optimizations)" ON)
 
@@ -45,8 +49,13 @@ endif()
 
 ## Use OpenMP by default
 option(USE_OMP "Build with OpenMP support" ON)
+option(REQUIRE_OMP "Require OpenMP and abort the build if not present" OFF)
 option(BUILD_PYTHON_MODULE "Build Python module" ON)
 option(BUILD_EXAMPLES "Build WallGo/Collision C++ examples" ON)
+
+if (REQUIRE_OMP)
+    set(USE_OMP ON)
+endif()
 
 if(BUILD_PYTHON_MODULE)
 	add_compile_definitions(WITH_PYTHON=1)

--- a/cmake/GenerateProjectVersion.cmake
+++ b/cmake/GenerateProjectVersion.cmake
@@ -1,0 +1,41 @@
+# Sets INOUT_VERSION in parent scope
+function(GenerateProjectVersion INOUT_VERSION)
+
+    if (DEFINED SKBUILD_PROJECT_VERSION)
+        # Get version number from scikit-build
+        set(LOCAL_VERSION ${SKBUILD_PROJECT_VERSION})
+    else()
+    
+        # Attempt to read git tag
+        find_package(Git QUIET)
+        if (GIT_FOUND)
+            # Will fail if ran outside a git repo, GIT_DESCRIBE_RESULT for success check
+            execute_process(
+                # get most recent tag
+                COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
+                OUTPUT_VARIABLE GIT_TAG
+                RESULT_VARIABLE GIT_DESCRIBE_RESULT
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+
+            if (GIT_DESCRIBE_RESULT EQUAL 0)
+                # tag is vX.Y.Z, strip the v
+                string(REGEX REPLACE "^v" "" GIT_TAG ${GIT_TAG})
+
+                # Strip all extra from semantic version. So leaves only X.Y.Z
+                string(REGEX REPLACE "^([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1" LOCAL_VERSION ${GIT_TAG})
+            endif()
+         
+        else()
+            #message(STATUS "Could not find package: Git")
+        endif()
+    endif()
+
+    if (NOT DEFINED LOCAL_VERSION)
+        # Fallback in case everything else failed
+        set(LOCAL_VERSION "0.0.0")
+        message(WARNING "Failed to determine project version from Git tags. Defaulting to \"${LOCAL_VERSION}\".")
+    endif()
+
+    set(${INOUT_VERSION} ${LOCAL_VERSION} PARENT_SCOPE)
+endfunction()

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,37 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.errors import ConanInvalidConfiguration
+
+import os
+
+class WallGoCollisionRecipe(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeToolchain", "CMakeDeps"
+
+    def requirements(self):
+        self.requires("gsl/2.7.1")
+        self.requires("hdf5/1.14.3")
+        self.requires("pybind11/2.11.1")
+        self.requires("muparser/2.3.4")
+        
+        """Require llvm-openmp recipe if env variable is set.
+        This version of OMP doesn't seem to work universally with our lib, so keep the option to use hidden.
+        """
+        ompEnvVar = os.getenv("WALLGO_USE_CONAN_OMP", "0")
+        if ompEnvVar != "0":
+
+            # llvm-openmp requires compiler.cppstd>=17
+            if self.settings.compiler.cppstd:
+                try:
+                    check_min_cppstd(self, 17)
+                    self.requires("llvm-openmp/18.1.8")
+                except ConanInvalidConfiguration as e:
+                    raise RuntimeError("\n\n!! Error from WallGoCollision !!\n"
+                        "You have set the 'WALLGO_USE_CONAN_OMP' environment variable which downloads and compiles OpenMP through Conan. "
+                        "This option requires compiler.cppstd >= 17 in your Conan 'default' profile. Please modify your profile accordingly, "
+                        "or set the environment variable to 0 or undefine it.\n\n"
+                        )
+        
+        
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.18]")

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,9 +1,0 @@
-[requires]
-gsl/2.7.1
-hdf5/1.14.3
-pybind11/2.11.1
-muparser/2.3.4
-
-[generators]
-CMakeDeps
-CMakeToolchain

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "scikit_build_core_conan.build"
 name = "WallGoCollision"
 description = "Python bindings for WallGo Collision module"
 readme = {file = "README.md", content-type = "text/markdown"}
-license = {text = "BSD 3.0"}
+license = {text = "GPL 3.0"}
 # get version from Github using setuptools_scm
 dynamic = ["version"]
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,14 @@
-# Uses scikit-build-core and its conan plugin scikit-build-core-conan to invoke install dependencies with Conan, then invoke CMake normally.
-# Makes the Collision module installable with pip:
-# pip install . [-v]
-# The -v is necessary to see what is going on under the hood (Conan, CMake messages).
-# Note that build artifacts will go wherever pip decides to put them .
-
 [build-system]
 requires = ["scikit-build-core-conan>=0.3.1", "pybind11>=2.13.1", "mypy>=1.11.1"]
 build-backend = "scikit_build_core_conan.build"
 
 [project]
 name = "WallGoCollision"
-version = "0.1.0"
 description = "Python bindings for WallGo Collision module"
-license = {text = "MIT"}
+readme = {file = "README.md", content-type = "text/markdown"}
+license = {text = "BSD 3.0"}
+# get version from Github using setuptools_scm
+dynamic = ["version"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
@@ -21,6 +17,9 @@ tests = [
 ]
 
 [tool.scikit-build]
+minimum-version = "0.10"
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
+sdist.include = ["python/packagedata/WallGoCollision/_version.py", "python/packagedata/WallGoCollision/*.pyi"]
 build.verbose = false
 cmake.build-type = "Release"
 # Run cmake before building wheel
@@ -28,15 +27,34 @@ wheel.cmake = true
 # Include files from these dirs in the wheel (__init__.py etc)
 wheel.packages = ["python/packagedata/WallGoCollision"]
 wheel.exclude = ["__pycache__/*"]
-sdist.include = ["python/packagedata/WallGoCollision/*.pyi"]
+
+[tool.setuptools_scm]
+write_to = "python/packagedata/WallGoCollision/_version.py"
+# Increments version if commit is ahead of the last tag
+version_scheme = "guess-next-dev"
 
 [tool.scikit-build.cmake.define]
+BUILD_PYTHON_MODULE = "ON"
+USE_OMP = "ON"
 # Disable compilation of CPP specific examples
 BUILD_EXAMPLES = "OFF"
-
-# Editable installs come with a bunch of issues, see https://scikit-build-core.readthedocs.io/en/latest/configuration.html#editable-installs
-# In particular, pip tends to delete the build dir after installation, so we lose the Conan toolchain file etc.
-# The docs recommend to preinstall dependencies when doing editable installs
+# Use env variable to mandate OpenMP during build. Used with cibuildwheel so that we don't accidentally build wheels without OMP
+REQUIRE_OMP = {env="WALLGO_REQUIRE_OMP", default="OFF"}
 
 [tool.scikit-build-core-conan]
 build = "missing"
+
+[tool.cibuildwheel]
+test-requires = "pytest"
+test-command = "pytest {project}/python/tests"
+# verbosity=1 corresponds to -v in pip
+build-verbosity = 1
+# Always require OMP with cibuildwheel. See cmake.defines above
+environment = "WALLGO_REQUIRE_OMP=ON"
+macos.environment = "WALLGO_USE_CONAN_OMP=1"
+# Only do 64bit manylinux archs for now, some 32bit manylinux archs have issues obtaining CMake during build
+linux.archs = ["auto64"]
+macos.archs = ["auto"]
+windows.archs = ["auto64"]
+# skip musllinux because the gsl recipe from conan failed to compile on them
+skip = "*musllinux_*"

--- a/python/packagedata/WallGoCollision/__init__.py
+++ b/python/packagedata/WallGoCollision/__init__.py
@@ -1,1 +1,3 @@
 from ._WallGoCollision import *
+
+__version__ = getVersionNumber()

--- a/python/src/BindToPython.cpp
+++ b/python/src/BindToPython.cpp
@@ -71,6 +71,9 @@ PYBIND11_MODULE(WG_PYTHON_MODULE_NAME, m)
             return bShouldExit;
         };
 
+    
+    m.def("getVersionNumber", []() { return py::str(WG_VERSION); }, "Returns WallGoCollision version number.");
+
     // Bind GSL seed setter
     m.def("setSeed", &wallgo::setSeed, py::arg("seed"), "Set seed used by Monte Carlo integration. Default is 0.");
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,8 @@ file(GLOB_RECURSE HEADERS "*.h" "*.inl")
 
 add_library(${WALLGO_LIB} ${SOURCES} ${HEADERS})
 
+target_compile_definitions(${WALLGO_LIB} PUBLIC WG_VERSION="${CMAKE_PROJECT_VERSION}")
+
 # Python module always has shared linkage, so the main lib needs PIC too if building for Python
 if(BUILD_SHARED_LIBS OR BUILD_PYTHON_MODULE)
     set(NEEDS_PIC ON)
@@ -28,7 +30,9 @@ find_package(HDF5 REQUIRED CXX)
 find_package(GSL REQUIRED CXX)
 find_package(muparser REQUIRED)
 
-if (USE_OMP)
+if (REQUIRE_OMP)
+    find_package(OpenMP REQUIRED)
+elseif (USE_OMP)
     find_package(OpenMP)
 endif()
 

--- a/src/include/WallGo/EnvironmentMacros.h
+++ b/src/include/WallGo/EnvironmentMacros.h
@@ -7,6 +7,11 @@ Doing so would require proper hiding ofSTL objects from the public interface (mo
 AND manually mark appropriate class members for exporting (not done). */
 #define WALLGO_API WALLGO_EXPORT
 
+// Version number passed from CMake
+#ifndef WG_VERSION
+    #define WG_VERSION "0.0.0"
+#endif
+
 #define WG_STRINGIFY(x) #x
 
 #ifdef _MSC_VER


### PR DESCRIPTION
Small enhancements to help with automated wheel building.

1. Added dynamic versioning: WG_VERSION in code, defined through CMake.
- In plain CMake builds, the version is read from Git tags if building inside Git repo. Otherwise defaults to "0.0.0".
- If scikit-build-core is running the build (eg. pip), the version number is obtained from setuptools_scm. This again parses it from git tags. Fails if the tag is more complicated than "vX.Y.Z".
- The CPython module defines getVersionNumber(), WallGoCollision package defines __version__

2. Changed to conanfile.py from the old conanfile.txt.
- Added option to download and install OpenMP through Conan during build.  Enable by defining environment variable WALLGO_USE_CONAN_OMP=1. Undefining or setting the var to 0 disables this.
- The recipe available on Conan is the LLVM implementation of OpenMP. It won't compile unless your Conan profile is explicitly set to use cppstd at least 17. Note that eg. GCC 9 does support C++17, but the default standard is gnu14 so the automatically detected Conan profile also defaults to that.
- Overall some care needed with this OMP recipe, so it's hidden behind an env variable for now. Confirmed to fail at linking stage on Windows MSVC 17, but works on macOS 14 and ubuntu 20.04.

3. Added cibuildwheel configuration to pyproject.toml. Updated also license there to BSD3.0.