### PR TITLE
Testing PyPI publish workflow

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -29,6 +29,11 @@ jobs:
     needs: make_sdist
     name: Publish to TestPyPI
     runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/WallGoCollision
+
     permissions:
       id-token: write
 
@@ -47,11 +52,10 @@ jobs:
         # Must put everything to dist/ for the pypa publish action to work 
         path: dist
         workflow_conclusion: success
-        #search_artifacts: true
         allow_forks: false
       
     - name: Publish to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
+        verbose: true
         repository-url: https://test.pypi.org/legacy/
-

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,4 +1,5 @@
 # This workflow makes a source distribution, downloads wheels built in the Build Wheels workflow and uploads to PyPI
+# Wheels will be downloaded from the most recent, successful run of the 'wheels.yml' workflow, on main branch.
 
 name: Publish to PyPI
 
@@ -53,12 +54,6 @@ jobs:
         workflow_conclusion: success
         allow_forks: false
 
-    # temp!
-    - name: "TEMP: upload full dist folder"
-      uses: actions/upload-artifact@v4
-      with:
-        path: dist/
-      
     - name: Publish to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -5,6 +5,7 @@ name: Publish to PyPI
 
 on:
   workflow_dispatch:
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -33,18 +33,23 @@ jobs:
       id-token: write
 
     steps:
+    - name: Download SDist
+      uses: actions/download-artifact@v4
+      with:
+        name: cibw-sdist
+        path: dist
+
     - name: Download built wheels
       uses: dawidd6/action-download-artifact@v6
       with:
-        workflow: wheels.yml
+        workflow: .github/workflows/wheels.yml
         branch: main
-        # empty name => download all artifacts
-        name:
         # Must put everything to dist/ for the pypa publish action to work 
         path: dist
-        search_artifacts: true
+        workflow_conclusion: success
+        #search_artifacts: true
         allow_forks: false
-
+      
     - name: Publish to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -59,8 +59,8 @@ jobs:
       run: |
         cd dist
         ls -l
-        mv cibw_wheels-*/*.whl .
-        rmdir cibw_wheels-*
+        mv cibw-wheels-*/*.whl .
+        rmdir cibw-wheels-*
         cd ..
 
     - name: Publish to TestPyPI

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -38,6 +38,8 @@ jobs:
       with:
         workflow: wheels.yml
         branch: main
+        # empty name => download all artifacts
+        name:
         # Must put everything to dist/ for the pypa publish action to work 
         path: dist
         search_artifacts: true

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -4,16 +4,12 @@
 name: Publish to PyPI
 
 on:
-  # Run after the Build Wheels workflow
-  workflow_run:
-    workflows: [Build Wheels]
-    types: [completed]
-    branches: [main]
+  workflow_dispatch:
 
 jobs:
-  
+
+  # Source distribution
   make_sdist:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Make SDist
     runs-on: ubuntu-latest
     steps:
@@ -30,27 +26,22 @@ jobs:
         path: dist/*.tar.gz
 
   publish_to_TestPyPI:
-    needs: [make_sdist]
-
-    # The 'success' check for triggering workflow may be redundant since we depend on make_sdist, but keep it just in case
-    #if: github.event_name == 'release' && github.event.action == 'published' && ${{ github.event.workflow_run.conclusion == 'success' }}
-    # TEMP for testing
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-
+    needs: make_sdist
     name: Publish to TestPyPI
     runs-on: ubuntu-latest
     permissions:
       id-token: write
 
     steps:
-    - name: Download built wheels from the triggering workflow
+    - name: Download built wheels
       uses: dawidd6/action-download-artifact@v6
       with:
-        run_id: ${{ github.event.workflow_run.id }}
-        pattern: cibw-*
+        workflow: wheels.yml
+        branch: main
         # Must put everything to dist/ for the pypa publish action to work 
         path: dist
         search_artifacts: true
+        allow_forks: false
 
     - name: Publish to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -59,7 +59,7 @@ jobs:
       run: |
         cd dist
         ls -l
-        mv cibw_wheels-*/*.whl
+        mv cibw_wheels-*/*.whl .
         rmdir cibw_wheels-*
         cd ..
 

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -6,6 +6,10 @@ name: Publish to PyPI
 on:
   workflow_dispatch:
 
+permissions:
+  pull-requests: read
+  actions: read
+
 jobs:
 
   # Source distribution

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -54,9 +54,14 @@ jobs:
         workflow_conclusion: success
         allow_forks: false
 
-    - name: Show contents of dist
-      # For debugging purposes
-      run: ls -l dist
+    - name: Unpack build wheels
+      # Need to be all on one level
+      run: |
+        cd dist
+        ls -l
+        mv cibw_wheels-*/*.whl
+        rmdir cibw_wheels-*
+        cd ..
 
     - name: Publish to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,14 +1,9 @@
-# This workflow makes a source distribution, downloads wheels built in the Build Wheels workflow and uploads to PyPI.
-# Does nothing if the wheel builder failed
+# This workflow makes a source distribution, downloads wheels built in the Build Wheels workflow and uploads to PyPI
 
 name: Publish to PyPI
 
 on:
   workflow_dispatch:
-
-permissions:
-  pull-requests: read
-  actions: read
 
 jobs:
 
@@ -57,6 +52,12 @@ jobs:
         path: dist
         workflow_conclusion: success
         allow_forks: false
+
+    # temp!
+    - name: "TEMP: upload full dist folder"
+      uses: actions/upload-artifact@v4
+      with:
+        path: dist/
       
     - name: Publish to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -5,7 +5,6 @@ name: Publish to PyPI
 
 on:
   workflow_dispatch:
-  pull_request:
 
 jobs:
 

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -54,6 +54,10 @@ jobs:
         workflow_conclusion: success
         allow_forks: false
 
+    - name: Show contents of dist
+      # For debugging purposes
+      run: ls -l dist
+
     - name: Publish to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,11 @@ sdist.include = [
     "python/packagedata/WallGoCollision/_version.py",
 ]
 sdist.exclude = [
+    ".gitattributes",
+    ".gitignore",
     ".github",
     "docs",
+    ".readthedocs.yml",
     "old"
 ]
 #


### PR DESCRIPTION
Draft PR for testing `publish_pypi.yml`. This version of the workflow downloads wheels from the latest successful run of the `build_wheels.yml` workflow on main branch. The publish workflow must now be ran manually, and since it's not yet on main branch this must be done through the Github CLI.

Fails to upload to TestPyPI for authentication reasons I don't understand.