### PR TITLE
Updates to docs (fixed)

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -18,15 +18,11 @@ contact.md
 license.md
 ```
 
-[**WallGoCollision**](https://github.com/Wall-Go/WallGoCollision) is a scientific library for computing Boltzmann collision integrals for use with the Python package [**WallGo**](https://wallgo.readthedocs.io). The library is written in C++17 and can be compiled as a Python module for seamless interoperation with WallGo. Collision integrations are typically by far the most computationally intensive part of the **WallGo** wall velocity pipeline. **WallGoCollision** performs these integrations using native C++, allowing for performance optimizations that would not be possible in a pure Python package.
-
-:::{important}
-[**WallGoCollision**](https://github.com/Wall-Go/WallGoCollision) is still in beta and may undergo large changes without notice. Use with care.
-:::
+[**WallGoCollision**](https://github.com/Wall-Go/WallGoCollision) is a scientific library for computing Boltzmann collision integrals for use with the Python package [**WallGo**](https://wallgo.readthedocs.io). The library is written in C++17 and can be compiled as a Python module for seamless interoperation with **WallGo**. Collision integrations are typically by far the most computationally intensive part of the **WallGo** wall velocity pipeline. **WallGoCollision** performs these integrations using native C++, allowing for performance optimizations that would not be possible in a pure Python package.
 
 ## What it does
 
-The purpose of **WallGoCollision** is to compute integrals of form
+The purpose of **WallGoCollision** is to compute integrals of the form
 
 $$
 \mathcal{C}_a[\delta f] \propto \sum_{bcd} \int \frac{d^3\mathbf{p}_2 d^3\mathbf{p}_3 d^3\mathbf{p}_4}{E_2 E_3 E_4} \delta^4(p_1 + p_2 - p_3 - p_4) |M_{ab \rightarrow cd}(p_1, p_2; p_3, p_4)|^2 \mathcal{P}_{ab \rightarrow cd}[\delta f],
@@ -41,5 +37,7 @@ can be computed automatically using the [WallGoMatrix](https://github.com/Wall-G
 ## Current limitations
 
 - Only 2-to-2 collision processes are supported.
+
+-  All momentum dependence in the matrix elements must be expressed in terms of the Mandelstam variables $s,t$ and $u$.
 
 - All physics parameters that appear in the matrix elements must be constant, floating point valued numbers. Dimensionful parameters must be given in units of the temperature (ie. **WallGoCollision** works in units of $T=1$). The limitation here is that parameters that vary along the momentum/position grid are not supported. 

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -1,6 +1,6 @@
 # Installation
 
-WallGoCollision can be installed with pip, using:
+WallGoCollision can be installed from the PyPI repository with pip, using:
 
     pip install WallGoCollision
 
@@ -10,7 +10,7 @@ Alternatively, below we give details on how to build the latest (unstable) devel
 
 ### Installing the Python extension module only (with pip)
 
-After cloning the [WallGoCollision repository](https://github.com/Wall-Go/WallGoCollision), run
+After cloning the [WallGoCollision repository](https://github.com/Wall-Go/WallGoCollision), the package can be built and installed with pip by running
 ```
 pip install . -v
 ```

--- a/docs/source/physics.md
+++ b/docs/source/physics.md
@@ -16,10 +16,10 @@ The collision term, $\mathcal C^{\text{lin}}_{ab}[\delta f^b]$, encodes the effe
 The collision term for particle species $a$ with momentum $p_1$ takes the form,
 
 $$
-\mathcal{C}_a[\delta f] = \frac{1}{4} \sum_{bcd} \int \frac{d^3\mathbf{p}_2 d^3\mathbf{p}_3 d^3\mathbf{p}_4}{(2\pi)^52E_2 2E_3 2E_4} \delta^4(p_1 + p_2 - p_3 - p_4) |M_{ab \rightarrow cd}(p_1, p_2; p_3, p_4)|^2 \mathcal{P}_{ab \rightarrow cd}[\delta f],
+\mathcal{C}_{ab}[\delta f] = \frac{1}{4} \sum_{cde} \int \frac{d^3\mathbf{p}_2 d^3\mathbf{p}_3 d^3\mathbf{p}_4}{(2\pi)^52E_2 2E_3 2E_4} \delta^4(p_1 + p_2 - p_3 - p_4) |M_{ac \rightarrow de}(p_1, p_2; p_3, p_4)|^2 \mathcal{P}_{ac \rightarrow de}[\delta f^b],
 $$
 
-where $M_{ab\to cd}$ is a 2-to-2 scattering matrix element, and $\mathcal{P}_{ab \rightarrow cd}[\delta f]$ is the linearised population factor. Further details can be found in the WallGo paper, or the paper of Cline & Laurent {footcite}`Laurent:2022jrs`.
+where $M_{ac\to de}$ is a 2-to-2 scattering matrix element, and $\mathcal{P}_{ac \rightarrow de}[\delta f^b]$ is the linearised population factor. Further details can be found in the WallGo paper, or the paper of Cline & Laurent {footcite}`Laurent:2022jrs`.
 
 The linear form of the collision term corresponds to the assumption that the particle species are close to equilibrium, $\delta f^a \ll f_{\text{eq}}^a$. If the species were at equilibrium the collision term would be indentically zero due to the detailed balance. Hence, expanding the full collision term around equilibrium yields the linear term on the leading order in $\delta f$.
 

--- a/docs/source/physics.md
+++ b/docs/source/physics.md
@@ -19,7 +19,7 @@ $$
 \mathcal{C}_a[\delta f] = \frac{1}{4} \sum_{bcd} \int \frac{d^3\mathbf{p}_2 d^3\mathbf{p}_3 d^3\mathbf{p}_4}{(2\pi)^52E_2 2E_3 2E_4} \delta^4(p_1 + p_2 - p_3 - p_4) |M_{ab \rightarrow cd}(p_1, p_2; p_3, p_4)|^2 \mathcal{P}_{ab \rightarrow cd}[\delta f],
 $$
 
-where $M_{ab\to cd}$ is a 2-to-2 scattering matrix element, and $\mathcal{P}_{ab \rightarrow cd}[\delta f]$ is the linearised population factor. Further details can be found in the paper of Cline & Laurent {footcite}`Laurent:2022jrs`.
+where $M_{ab\to cd}$ is a 2-to-2 scattering matrix element, and $\mathcal{P}_{ab \rightarrow cd}[\delta f]$ is the linearised population factor. Further details can be found in the WallGo paper, or the paper of Cline & Laurent {footcite}`Laurent:2022jrs`.
 
 The linear form of the collision term corresponds to the assumption that the particle species are close to equilibrium, $\delta f^a \ll f_{\text{eq}}^a$. If the species were at equilibrium the collision term would be indentically zero due to the detailed balance. Hence, expanding the full collision term around equilibrium yields the linear term on the leading order in $\delta f$.
 

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -18,7 +18,7 @@ modelDef = WallGoCollision.ModelDefinition()
 gs = 1.228 # Corresponds to the QCD coupling
 modelDef.defineParameter("gs", gs) 
 ```
-Parameters must be given as (name, value) pairs. The value must be floating-point type or convertible to such, eg. complex numbers are not allowed. In the above, "gs" is the parameter name, and any appearance of "gs" in the symbolic matrix elements will be replaced with the numeric value during collision integration.
+Parameters must be given as (name, value) pairs. The value must be floating-point type or convertible to such, e.g. complex numbers are not allowed. In the above, "gs" is the parameter name, and any appearance of "gs" in the symbolic matrix elements will be replaced with the numeric value during collision integration.
 
 Next we define our particle content using the ParticleDefinition class. Each particle species must have a unique name (string) as well as a unique integer identifier ("particle index"). The index is used to associate loaded matrix elements with the correct particles. Additionally, you must specify the particle statistics type (boson or fermion), and whether the species is assumed to remain in thermal equilibrium. The latter can be used to reduce the number of collision integrations for models containing particle species for which deviations from equilibrium are negligible. Here we define a "Top Quark" and a "Gluon" as out-of-equilibrium particles, and a generic "Light Quark" that is kept in equilibrium.
 ```
@@ -44,15 +44,15 @@ lightQuark.type = WallGoCollision.EParticleType.eFermion
 lightQuark.bInEquilibrium = True
 modelDef.defineParticleSpecies(lightQuark)
 ```
-The above particle species are all defined as "ultrarelativistic" (the default behavior). In **WallGoCollision**, an ultrarelativistic particle species $a$ means that its energy-momentum dispersion relation is approximated as $E_a \approx |p_a|$ in collision integrals. This allows for heavy optimizations and should be preferred whenever the approximation makes sense for your particles. For going beyond the ultrarelativistic approximation, see [here (TODO! empty link for now)]().
+The above particle species are all defined as "ultrarelativistic" (the default behavior). In **WallGoCollision**, an ultrarelativistic particle species $a$ means that its energy-momentum dispersion relation is approximated as $E_a \approx |p_a|$ in collision integrals. This is sufficient at leading-logarithmic order. It also allows for heavy optimizations and should be preferred whenever the approximation makes sense for your particles. For going beyond the ultrarelativistic approximation, see [here (TODO! empty link for now)]().
 
-Finally, we should define numerical values for masses that appear in propagators of matrix elements. In **WallGoCollision**, these masses are treated as model parameters analogous to the "gs" parameter defined above, ie. a propagator mass is just another user-defined symbol that can appear in matrix elements and must be given a numberical value. In the matrix elements for this example, the mass-square of a quark propagator is denoted by "mq2" and the mass-square of a gluon propagator is "mg2". For this model we approximate them as their asymptotic QCD thermal masses (same for all quark species):
+Finally, we should define numerical values for masses that appear in propagators of matrix elements. In **WallGoCollision**, these masses are treated as model parameters analogous to the "gs" parameter defined above, i.e. a propagator mass is just another user-defined symbol that can appear in matrix elements and must be given a numberical value. In the matrix elements for this example, the mass-square of a quark propagator is denoted by "mq2" and the mass-square of a gluon propagator is "mg2". For this model we approximate them as their asymptotic QCD thermal masses (same for all quark species):
 ```
 modelDef.defineParameter("mq2", gs**2 / 3.0)
 modelDef.defineParameter("mg2", gs**2)
 ```
 :::{note}
-Any dimensionful parameters must be given in units of the temperature. Therefore the above corresponds to eg. $\frac13 g_s^2 T^2$ for the quark mass-square.
+Any dimensionful parameters must be given in units of the temperature. Therefore the above corresponds to e.g. $\frac13 g_s^2 T^2$ for the quark mass-square.
 :::
 
 To finalize our model definition we create a concrete `PhysicsModel` based on the information in our `modelDef` object:
@@ -63,9 +63,9 @@ Once created, the particle and parameter content of a `PhysicsModel` is fixed an
 
 ## Loading matrix elements
 
-The next step is to specify what collision processes are allowed in the model. This is done by loading symbolic (ie. math expressions) matrix elements for the relevant processes from an external file. Finding matrix elements for a given particle physics model is an exercise in field theory and not within capabilities of **WallGoCollision**. The companion Mathematica package [**WallGoMatrix**](https://github.com/Wall-Go/WallGoMatrix) can be used to generate matrix elements for arbitrary models, directly in the format required to **WallGoCollision**.
+The next step is to specify what collision processes are allowed in the model. This is done by loading symbolic (i.e. math expressions) matrix elements for the relevant processes from an external file. Finding matrix elements for a given particle physics model is an exercise in field theory and not within the capabilities of **WallGoCollision**. The companion Mathematica package [**WallGoMatrix**](https://github.com/Wall-Go/WallGoMatrix) can be used to generate matrix elements for arbitrary models, directly in the format required to **WallGoCollision**.
 
-**WallGoCollision** supports matrix element parsing in JSON format (needs `.json` file extension) or from generic text files (legacy option). The JSON format is generally recommended for better validation; the `.json` matrix elements relevant for this example are available [here](https://github.com/Wall-Go/WallGoCollision/tree/main/examples/MatrixElements/MatrixElements_QCD.json). A legacy `.txt` version is available [here](https://github.com/Wall-Go/WallGoCollision/tree/main/examples/MatrixElements/MatrixElements_QCD.txt), note that the formatting must be exactly as shown in the file for parsing to work. Each matrix element must specify indices of external particles participating in the collision process, and a symbolic expression that is typically a function of Mandelstam variables (denoted by reserved symbols "_s", "_t", "_u") and of any user-specified symbols (such as "gs" in this example).
+**WallGoCollision** supports matrix element parsing in JSON format (needs `.json` file extension) or from generic text files (legacy option). The JSON format is generally recommended for better validation; the `.json` matrix elements relevant for this example are available [here](https://github.com/Wall-Go/WallGoCollision/tree/main/examples/MatrixElements/MatrixElements_QCD.json). A legacy `.txt` version is available [here](https://github.com/Wall-Go/WallGoCollision/tree/main/examples/MatrixElements/MatrixElements_QCD.txt), note that the formatting of the `.txt` file must be exactly as shown there for parsing to work. Each matrix element must specify indices of external particles participating in the collision process, and a symbolic expression that is typically a function of Mandelstam variables (denoted by reserved symbols "_s", "_t", "_u") and of any user-specified symbols (such as "gs" in this example).
 
 Matrix elements are loaded to a PhysicsModel as follows:
 ```
@@ -87,13 +87,13 @@ collisionTensor: WallGoCollision.CollisionTensor = collisionModel.createCollisio
 ```
 `gridSize` is the number of basis polynomials on your momentum/polynomial grid as used by the **WallGo** pipeline, and must be integer. It can be freely changed later with `collisionTensor.changePolynomialBasisSize(newSize)`.
 
-Before starting integrations it can be useful to configure the integrator to best suit your needs. A handful of settings is available in the `IntegrationOptions` class, including error tolerances for the Monte Carlo integration and the upper limit on momentum integration. You can then pass your modified `IntegrationOptions` object to `CollisionTensor` as `collisionTensor.setIntegrationOptions(yourOptionsObject)`. Here we skip this step and use the default settings. Similarly, the `CollisionTensorVerbosity` class can be used to configure verbosity settings, such as progress reporting and time estimates. Set it as `collisionTensor.setIntegrationVerbosity(yourVerbosityObject)`.
+Before starting integrations it can be useful to configure the integrator to best suit your needs. A handful of settings are available in the `IntegrationOptions` class, including error tolerances for the Monte Carlo integration and the upper limit on momentum integration. You can then pass your modified `IntegrationOptions` object to `CollisionTensor` as `collisionTensor.setIntegrationOptions(yourOptionsObject)`. Here we skip this step and use the default settings. Similarly, the `CollisionTensorVerbosity` class can be used to configure verbosity settings, such as progress reporting and time estimates. Set it as `collisionTensor.setIntegrationVerbosity(yourVerbosityObject)`.
 
 To perform the actual integrations, use
 ```
 results: WallGoCollision.CollisionTensorResult = collisionTensor.computeIntegralsAll()
 ```
-This is typically a very long running functions for nontrivial models and grid sizes. For grid size $N$ the number of required integrals scales as $(N-1)^4$. The return type CollisionTensorResult is a wrapper around 4D numerical array that contains statistical error estimates of the Monte Carlo integration.  Once finished, you can save the results in `.hdf5` format as follows:
+This is typically a very long running functions for nontrivial models and grid sizes. For grid size $N$ the number of required integrals scales as $(N-1)^4$. The return type CollisionTensorResult is a wrapper around a 4D numerical array that contains statistical error estimates of the Monte Carlo integration.  Once finished, you can save the results in `.hdf5` format as follows:
 ```
 # Replace with your output directory
 results.writeToIndividualHDF5("CollisionOutDir/")


### PR DESCRIPTION
Updates to the docs for v1 release:
- Removed beta warning
- Added limitation from draft
- Several tweaks to wording

N.B. this is a new PR from PR #16, which had some messy merge conflict which has been avoided here by branching again off main and just taking the new stuff.

To see this PR on ReadTheDocs, go to: https://wallgocollision.readthedocs.io/en/docsupdatev1fix/