### PR TITLE
Compute for pair

### DIFF
--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -11,7 +11,7 @@ Alternatively, below we give details on how to build the latest (unstable) devel
 ### Installing the Python extension module only (with pip)
 
 After cloning the [WallGoCollision repository](https://github.com/Wall-Go/WallGoCollision), the package can be built and installed with pip by running
-```
+```bash
 pip install . -v
 ```
 
@@ -54,14 +54,14 @@ We compile with OpenMP support by default, needed for parallel evaluation of int
 **Important:** The Python bindings are version dependent and guaranteed to work only with the same version of Python that was used during compilation. We default to the version returned by CMake's FindPython3 which is usually the most recent version of Python. If you have multiple Python installations on your system, you can specify the correct version with `-DUSER_PYTHON_VERSION=3.XX` in the `-B` step (replace 3.XX with eg. 3.12 for Python 3.12). If you still have issues, you can try `-DPython3_ROOT_DIR="path/to/python"` to specify the location of your preferred Python installation.
 
 **Note:** On Windows systems you may have to specify the build configuration explicitly:
-```
+```bash
 cmake --build build --config Release
 ```
 
 ### Installing dependenciens with Conan
 
 Easiest way of handling the dependencies is with the Conan package manager (can be installed with eg. `pip`). We require Conan version >= 2.0. The build proceeds as:
-```
+```bash
 conan install . --output-folder=build --build=missing
 cmake -B build -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake
 cmake --build build
@@ -71,17 +71,17 @@ cmake --install build
 ### Manually installing dependencies
 
 Linux:
-```
+```bash
 sudo apt-get install libgsl-dev libhdf5-dev
 ```
 
 MacOS: 
-```
+```bash
 brew install gsl hdf5 muparser
 ```
 
 For both systems, pybind11 can be installed using pip:
-```
+```bash
 pip install "pybind11[global]"
 ```
 This installation needs to be global, otherwise pip doesn't install the required CMake files. Alternatively, you could install pybind11 through `conda` or build it directly from source.

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -13,7 +13,7 @@ The following assumes you have the **WallGoCollision** Python module [installed]
 ## Defining the model
 
 Model definition is done by filling in a ModelDefinition helper object and passing it to the PhysicsModel constructor. Start by defining your model parameters:
-```
+```python
 modelDef = WallGoCollision.ModelDefinition()
 gs = 1.228 # Corresponds to the QCD coupling
 modelDef.defineParameter("gs", gs) 
@@ -21,7 +21,7 @@ modelDef.defineParameter("gs", gs)
 Parameters must be given as (name, value) pairs. The value must be floating-point type or convertible to such, e.g. complex numbers are not allowed. In the above, "gs" is the parameter name, and any appearance of "gs" in the symbolic matrix elements will be replaced with the numeric value during collision integration.
 
 Next we define our particle content using the ParticleDefinition class. Each particle species must have a unique name (string) as well as a unique integer identifier ("particle index"). The index is used to associate loaded matrix elements with the correct particles. Additionally, you must specify the particle statistics type (boson or fermion), and whether the species is assumed to remain in thermal equilibrium. The latter can be used to reduce the number of collision integrations for models containing particle species for which deviations from equilibrium are negligible. Here we define a "Top Quark" and a "Gluon" as out-of-equilibrium particles, and a generic "Light Quark" that is kept in equilibrium.
-```
+```python
 topQuark = WallGoCollision.ParticleDescription()
 topQuark.name = "Top"
 topQuark.index = 0
@@ -56,7 +56,7 @@ Any dimensionful parameters must be given in units of the temperature. Therefore
 :::
 
 To finalize our model definition we create a concrete `PhysicsModel` based on the information in our `modelDef` object:
-```
+```python
 collisionModel = WallGoCollision.PhysicsModel(modelDef)
 ```
 Once created, the particle and parameter content of a `PhysicsModel` is fixed and cannot be changed. You are still allowed to update values of existing parameters by calling `model.updateParameter(name, newValue)`. Runtime changes to a PhysicsModel will automatically propagate to `CollisionTensor` objects created from it.
@@ -68,7 +68,7 @@ The next step is to specify what collision processes are allowed in the model. T
 **WallGoCollision** supports matrix element parsing in JSON format (needs `.json` file extension) or from generic text files (legacy option). The JSON format is generally recommended for better validation; the `.json` matrix elements relevant for this example are available [here](https://github.com/Wall-Go/WallGoCollision/tree/main/examples/MatrixElements/MatrixElements_QCD.json). A legacy `.txt` version is available [here](https://github.com/Wall-Go/WallGoCollision/tree/main/examples/MatrixElements/MatrixElements_QCD.txt), note that the formatting of the `.txt` file must be exactly as shown there for parsing to work. Each matrix element must specify indices of external particles participating in the collision process, and a symbolic expression that is typically a function of Mandelstam variables (denoted by reserved symbols "_s", "_t", "_u") and of any user-specified symbols (such as "gs" in this example).
 
 Matrix elements are loaded to a PhysicsModel as follows:
-```
+```python
 # Replace with your own path. The second argument is optional and specifies whether the loaded matrix elements should be printed for logging purposes
 bSuccess: bool = collisionModel.loadMatrixElements("MatrixElements/MatrixElements_QCD.json", True)
 ```
@@ -79,7 +79,7 @@ This parses the file and finds matrix elements for particles that the model is a
 ## `CollisionTensor` creation and evaluation
 
 The `CollisionTensor` class contains collision integrals in an unevaluated but otherwise ready form. Once matrix elements have been loaded we can create a `CollisionTensor` object as follows:
-```
+```python
 # Modify according to your needs. Using a trivially small grid to make this example run fast
 gridSize = 5
 # Type hinting included for completeness
@@ -90,20 +90,20 @@ collisionTensor: WallGoCollision.CollisionTensor = collisionModel.createCollisio
 Before starting integrations it can be useful to configure the integrator to best suit your needs. A handful of settings are available in the `IntegrationOptions` class, including error tolerances for the Monte Carlo integration and the upper limit on momentum integration. You can then pass your modified `IntegrationOptions` object to `CollisionTensor` as `collisionTensor.setIntegrationOptions(yourOptionsObject)`. Here we skip this step and use the default settings. Similarly, the `CollisionTensorVerbosity` class can be used to configure verbosity settings, such as progress reporting and time estimates. Set it as `collisionTensor.setIntegrationVerbosity(yourVerbosityObject)`.
 
 To perform the actual integrations, use
-```
+```python
 results: WallGoCollision.CollisionTensorResult = collisionTensor.computeIntegralsAll()
 ```
 This is typically a very long running functions for nontrivial models and grid sizes. For grid size $N$ the number of required integrals scales as $(N-1)^4$. The return type CollisionTensorResult is a wrapper around a 4D numerical array that contains statistical error estimates of the Monte Carlo integration.  Once finished, you can save the results in `.hdf5` format as follows:
-```
+```python
 # Replace with your output directory
 results.writeToIndividualHDF5("CollisionOutDir/")
 ```
 This creates a separate `.hdf5` for each pair of out-of-equilibrium particles in the model in the specified output directory. The data can then be readily loaded into [**WallGo**](https://wallgo.readthedocs.io).
 
 It is also possible to calculate only parts of the collision tensor by fixing particle indices (see also the [docs on physics](physics.md)). For example, the part of $\mathcal C^{\text{lin}}_{ab}$ that mixes distributions of "top" and "gluon" particles in the Boltzmann equation of "top" can be computed as follows:
-```
+```python
 results_tg = collisionTensor.computeIntegralsForPair("top", "gluon")
 # Save as .hdf5
-results_tg.writeToHDF5("CollisionOutDir/collisions_top_gluon.hdf5", False)
+results_tg.writeToHDF5("CollisionOutDir/collisions_top_gluon.hdf5")
 ```
 This is useful for avoiding redundant computations when changing model parameters in a way that only affects some collision terms.

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -99,3 +99,11 @@ This is typically a very long running functions for nontrivial models and grid s
 results.writeToIndividualHDF5("CollisionOutDir/")
 ```
 This creates a separate `.hdf5` for each pair of out-of-equilibrium particles in the model in the specified output directory. The data can then be readily loaded into [**WallGo**](https://wallgo.readthedocs.io).
+
+It is also possible to calculate only parts of the collision tensor by fixing particle indices (see also the [docs on physics](physics.md)). For example, the part of $\mathcal C^{\text{lin}}_{ab}$ that mixes distributions of "top" and "gluon" particles in the Boltzmann equation of "top" can be computed as follows:
+```
+results_tg = collisionTensor.computeIntegralsForPair("top", "gluon")
+# Save as .hdf5
+results_tg.writeToHDF5("CollisionOutDir/collisions_top_gluon.hdf5", False)
+```
+This is useful for avoiding redundant computations when changing model parameters in a way that only affects some collision terms.

--- a/python/src/BindToPython.cpp
+++ b/python/src/BindToPython.cpp
@@ -71,14 +71,14 @@ PYBIND11_MODULE(WG_PYTHON_MODULE_NAME, m)
             return bShouldExit;
         };
 
-    
+
     m.def("getVersionNumber", []() { return py::str(WG_VERSION); }, "Returns WallGoCollision version number.");
 
     // Bind GSL seed setter
     m.def("setSeed", &wallgo::setSeed, py::arg("seed"), "Set seed used by Monte Carlo integration. Default is 0.");
 
     // Will need to do static_casts to specific function signatures when binding overloaded functions,
-    // see https://pybind11.readthedocs.io/en/stable/classes.html#overloaded-methods 
+    // see https://pybind11.readthedocs.io/en/stable/classes.html#overloaded-methods
 
     py::class_<GridPoint>(m, "GridPoint",
         R"(Point (m, n; j, k) on polynomial/momentum grid.
@@ -155,7 +155,7 @@ PYBIND11_MODULE(WG_PYTHON_MODULE_NAME, m)
             Can be None if the pair is not found)",
             py::arg("particle1"), py::arg("particle2")
         );
-    
+
     py::class_<CollisionIntegral4>(m,
         "CollisionIntegral4",
         R"(Describes a collision integral for 2 -> 2 scattering process.
@@ -198,6 +198,11 @@ PYBIND11_MODULE(WG_PYTHON_MODULE_NAME, m)
             py::return_value_policy::reference_internal,
             R"(Get reference to specified CollisionIntegral4 object. Intended mainly for debugging purposes,
             eg. if you need the value of the integrand at a specific point for comparison with other codes.)"
+        ).def("computeIntegralsForPair",
+            static_cast<CollisionResultsGrid(CollisionTensor::*)(const std::string&, const std::string&)>(&CollisionTensor::computeIntegralsForPair),
+            py::call_guard<py::gil_scoped_release>(),
+            R"(Computes collision integrals for the specified particle pair only. Does not hold GIL.)",
+            py::arg("particle1"), py::arg("particle2")
         );
 
     py::class_<ModelParameters>(m, "ModelParameters", "Container for physics model-dependent parameters (couplings etc)")

--- a/python/tests/test_collisionIntegration.py
+++ b/python/tests/test_collisionIntegration.py
@@ -7,9 +7,11 @@ def test_getIntegralForPair(collisionTensorQCD: WallGoCollision.CollisionTensor)
     integral = collisionTensorQCD.getIntegralForPair("top", "top")
     assert integral is not None
     assert isinstance(integral, WallGoCollision.CollisionIntegral4)
-    
+
     nonExistentIntegral = collisionTensorQCD.getIntegralForPair("dumb1", "dumb2")
     assert nonExistentIntegral is None
+
+
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
@@ -39,3 +41,41 @@ def test_collisionTensorFull(
     assert resultsForPair.valueAt(
         WallGoCollision.GridPoint(*gridPoint)
     ) == pytest.approx(expected, rel=0.05)
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "particle1, particle2, gridPoint, expected",
+    [
+        ("gluon", "gluon", (3, 2, 1, 2), -0.235728),
+    ]
+)
+def test_collisionTensorPair(
+    collisionTensorQCD: WallGoCollision.CollisionTensor,
+    particle1: str,
+    particle2: str,
+    gridPoint: tuple,
+    expected: float,
+) -> None:
+    """Integrates collision tensor for a specified particle pair only."""
+
+    WallGoCollision.setSeed(0)
+
+    collisionTensorQCD.changePolynomialBasisSize(3)
+
+    options = WallGoCollision.IntegrationOptions()
+    options.maxIntegrationMomentum = 20
+    options.absoluteErrorGoal = 1e-8
+    options.relativeErrorGoal = 1e-1
+    options.maxTries = 50
+    options.calls = 50000
+    options.bIncludeStatisticalErrors = True
+
+    collisionTensorQCD.setIntegrationOptions(options)
+
+    res = collisionTensorQCD.computeIntegralsForPair(particle1, particle2)
+    assert res is not None
+    assert isinstance(res, WallGoCollision.CollisionResultsGrid)
+
+    point = WallGoCollision.GridPoint(*gridPoint)
+    assert res.valueAt(point) == pytest.approx(expected, rel=0.05)
+

--- a/src/include/WallGo/CollisionTensor.h
+++ b/src/include/WallGo/CollisionTensor.h
@@ -18,28 +18,16 @@
 #include "ModelObserver.h"
 
 
-/** How we manage particles. Calling addParticle(particle) registers a new particle with the CollisionTensor.
- * We take a copy of the particle struct and store them as unique pointers in our 'particles' list.
- * Each CollisionElement needs raw pointers to its external particles, so when new CollElems are created through the manager
- * we pass references to appropriate particles from our 'particles' list.
- */
-
-/** Handling of model parameters. The manager holds a map of [string, double] pairs that can be updated
- * through CollisionTensor::setVariable(key, val). These need to be defined before parsing matrix elements,
- * otherwise the parsing will error out due to undefined symbols. Each matrix element will hold their own internal map
- * of parameter values, so if they change at any point, it is up to the manager to sync all built CollisionIntegral objects
- * and their stored MatrixElement objects. 
- * 
- * TODO: Would it be better to pass the parameters to matrix elements as pointers too? 
-*/
-
 namespace wallgo
 {
 
 class PhysicsModel;
 
 
-/**/
+/* Class CollisionTensor -- Contains collision integrals in an unevaluated form
+and provides an interface for evaluating them.
+Uses an observer pattern to automatically detect changes in the PhysicsModel instance that created it.
+*/
 class CollisionTensor : public IModelObserver
 {
 


### PR DESCRIPTION
Adds Python bindings to `CollisionTensor::computeForPair` function. This calculates a slice of the collision tensor at fixed particle indices