### PR TITLE
Update wheel build dependencies 

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,7 +22,7 @@ jobs:
           os: [
               ubuntu-latest,
               windows-latest,
-              #macos-13,
+              macos-15-intel,
               macos-14
             ]
 
@@ -32,7 +32,7 @@ jobs:
         with:
           # Fetch everything to ensure we get tags
           fetch-depth: 0
-      
+
       # Install Conan here already because we want to cache/restore its installed dependencies.
       # TODO: Caching requires more work on linux wheels since those happen inside Docker environment
       - name: Install Conan
@@ -58,13 +58,12 @@ jobs:
       - if: ${{ steps.cache-conan.outputs.cache-hit != 'true' }}
         name: Create default Conan profile if no cache was hit
         run: conan profile detect --exist-ok
-      
+
       - name: Build and test wheels (cibuildwheel)
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}
           path: wheelhouse/*.whl
-          

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -60,7 +60,7 @@ jobs:
         run: conan profile detect --exist-ok
 
       - name: Build and test wheels (cibuildwheel)
-        uses: pypa/cibuildwheel@3.3.0
+        uses: pypa/cibuildwheel@v3.3.0
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -60,7 +60,7 @@ jobs:
         run: conan profile detect --exist-ok
 
       - name: Build and test wheels (cibuildwheel)
-        uses: pypa/cibuildwheel
+        uses: pypa/cibuildwheel@3.3.0
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,7 +22,7 @@ jobs:
           os: [
               ubuntu-latest,
               windows-latest,
-              macos-15-intel,
+              #macos-15-intel,
               macos-14
             ]
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,8 +12,8 @@ class WallGoCollisionRecipe(ConanFile):
         self.requires("gsl/2.7.1")
         self.requires("hdf5/1.14.3")
         self.requires("pybind11/2.11.1")
-        self.requires("muparser/2.3.4")
-        
+        self.requires("muparser/2.3.5")
+
         """Require llvm-openmp recipe if env variable is set.
         This version of OMP doesn't seem to work universally with our lib, so keep the option to use hidden.
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ macos.environment = {WALLGO_USE_CONAN_OMP="1", MACOSX_DEPLOYMENT_TARGET="11.0"}
 linux.archs = ["auto64"]
 macos.archs = ["auto"]
 windows.archs = ["auto64"]
-# Skip musllinux because the gsl recipe from conan failed to compile on them
-skip = "*musllinux_*"
-# Skip PyPy wheels on all platforms. Too much hassle with C-extensions and no demand
-skip = "pp*"
+# Skip musllinux because the gsl recipe from conan failed to compile on them.
+# Skip PyPy wheels on all platforms. Too much hassle with C-extensions and no demand.
+skip = ["*musllinux_*", "pp*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,5 +74,7 @@ macos.environment = {WALLGO_USE_CONAN_OMP="1", MACOSX_DEPLOYMENT_TARGET="11.0"}
 linux.archs = ["auto64"]
 macos.archs = ["auto"]
 windows.archs = ["auto64"]
-# skip musllinux because the gsl recipe from conan failed to compile on them
+# Skip musllinux because the gsl recipe from conan failed to compile on them
 skip = "*musllinux_*"
+# Skip PyPy wheels on all platforms. Too much hassle with C-extensions and no demand
+skip = "pp*"


### PR DESCRIPTION
Now builds wheels for Python 3.14 too.

- Skip PyPy wheels as they now fail to build due to some C-extension incompatibilities. Quite miraculous that they worked until now.
-MacOS-x86 still gets wrong arch somehow and fails so not including that.

https://github.com/Wall-Go/WallGoCollision/actions/runs/20160749787